### PR TITLE
Fixes for ROX&RWO mount

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,7 +12,7 @@
 CSI_IMAGE_VERSION=v3.3.1
 
 # Ceph version to use
-BASE_IMAGE=docker.io/ceph/ceph:v15
+BASE_IMAGE=quay.io/ceph/ceph:v15
 CEPH_VERSION=octopus
 
 # standard Golang options

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE} as builder
 
 LABEL stage="build"
 
-ARG CSI_IMAGE_NAME=quay.io/cephcsi/cephcsi
+ARG CSI_IMAGE_NAME=reg.supremind.info/shenyijie/ceph-csi
 ARG CSI_IMAGE_VERSION=canary
 ARG GO_ARCH
 ARG SRC_DIR
@@ -23,11 +23,28 @@ RUN source /build.env && \
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 
+
+RUN sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+    -e 's|^#baseurl=http://mirror.centos.org/$contentdir|baseurl=https://mirrors.ustc.edu.cn/centos|g' \
+    -i.bak \
+    /etc/yum.repos.d/CentOS-Stream-AppStream.repo \
+    /etc/yum.repos.d/CentOS-Stream-BaseOS.repo \
+    /etc/yum.repos.d/CentOS-Stream-Debuginfo.repo \
+    /etc/yum.repos.d/CentOS-Stream-Extras.repo \
+    /etc/yum.repos.d/CentOS-Stream-HighAvailability.repo \
+    /etc/yum.repos.d/CentOS-Stream-Media.repo \
+    /etc/yum.repos.d/CentOS-Stream-PowerTools.repo \
+    /etc/yum.repos.d/CentOS-Stream-RealTime.repo 
+
+RUN dnf config-manager --disable apache-arrow-centos || true
+
+RUN yum clean all && yum makecache 
+
 RUN dnf -y install \
-	librados-devel librbd-devel \
-	/usr/bin/cc \
-	make \
-	git \
+    librados-devel librbd-devel \
+    /usr/bin/cc \
+    make \
+    git \
     && true
 
 ENV GOROOT=${GOROOT} \

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1123,3 +1123,18 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		NodeExpansionRequired: nodeExpansion,
 	}, nil
 }
+
+// ControllerPublishVolume collects information useful for NodeStageVolume to tell if the volume is expected to be mounted readonly.
+func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	ro := "false"
+	if req.GetReadonly() {
+		ro = "true"
+	}
+
+	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{"readonly": ro}}, nil
+}
+
+// ControllerUnpublishVolume does nothing.
+func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1131,7 +1131,7 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		ro = "true"
 	}
 
-	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{"csi.supremind.com/readonly-attach": ro}}, nil
+	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro}}, nil
 }
 
 // ControllerUnpublishVolume does nothing.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1131,7 +1131,7 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		ro = "true"
 	}
 
-	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{"readonly": ro}}, nil
+	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{"csi.supremind.com/readonly-attach": ro}}, nil
 }
 
 // ControllerUnpublishVolume does nothing.

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -133,6 +133,8 @@ func (r *Driver) Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+			csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
+			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 		})
 		// We only support the multi-writer option when using block, but it's a supported capability for the plugin in general
 		// In addition, we want to add the remaining modes like MULTI_NODE_READER_ONLY,

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,8 +117,10 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
+	disableInUseChecks := req.GetPublishContext()["readonly"] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
-	disableInUseChecks := false
+	// disableInUseChecks := false
+
 	// MULTI_NODE_MULTI_WRITER is supported by default for Block access type volumes
 	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
 		if !isBlock {
@@ -458,6 +460,17 @@ func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeS
 	}
 	if csicommon.MountOptionContains(opt, rOnly) {
 		readOnly = true
+		// mount readonly files with noload option
+		// opt = append(opt, "noload")
+		// err = diskMounter.FormatAndMount(devicePath, stagingPath, fsType, opt)
+		// if err != nil {
+		// 	util.ErrorLog(ctx, "failed to mount device path (%s) to staging path (%s) for readonly volume "+
+		// 		"(%s) error: %s Check dmesg logs if required.", devicePath,
+		// 		stagingPath,
+		// 		req.GetVolumeId(),
+		// 		err)
+		// }
+
 	}
 
 	if fsType == "xfs" {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,7 +117,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
-	disableInUseChecks := req.GetPublishContext()["readonly"] == "true"
+	disableInUseChecks := req.GetPublishContext()["csi.supremind.com/readonly-attach"] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	// disableInUseChecks := false
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,7 +117,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
-	disableInUseChecks := req.GetPublishContext()["csi.supremind.com/readonly-attach"] == "true"
+	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	// disableInUseChecks := false
 
@@ -460,17 +460,6 @@ func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeS
 	}
 	if csicommon.MountOptionContains(opt, rOnly) {
 		readOnly = true
-		// mount readonly files with noload option
-		// opt = append(opt, "noload")
-		// err = diskMounter.FormatAndMount(devicePath, stagingPath, fsType, opt)
-		// if err != nil {
-		// 	util.ErrorLog(ctx, "failed to mount device path (%s) to staging path (%s) for readonly volume "+
-		// 		"(%s) error: %s Check dmesg logs if required.", devicePath,
-		// 		stagingPath,
-		// 		req.GetVolumeId(),
-		// 		err)
-		// }
-
 	}
 
 	if fsType == "xfs" {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -58,6 +58,8 @@ const (
 
 	// image metadata key for thick-provisioning
 	thickProvisionMetaKey = ".rbd.csi.ceph.com/thick-provisioned"
+	// volume metadata key for attachment
+	readonlyAttachmentKey = "csi.supremind.com/readonly-attach"
 )
 
 // rbdImage contains common attributes and methods for the rbdVolume and


### PR DESCRIPTION

# Describe what this PR does #

Allow mounting RBD volume RWO or ROX

- add controllerPublishVolume & controller UnpubliishVolume to tell following steps if the volume is expected mounted read only
- do not check if rbd is in use if it's readonly in NodeStageVolume
- patch based on commit c65c29880be840198875307d0af0429b9ec3f13f

## Is there anything that requires special attention ##

Is the change backward compatible?

Are there concerns around backward compatibility?

No

Provide any external context for the change, if any.

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

https://github.com/supremind/external-attacher/pull/2

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

---


