### PR TITLE
noload option appended

### DIFF
--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -8,4 +8,4 @@ metadata:
   name: {{ .Values.driverName }}
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -36,7 +36,7 @@ RUN sudo sed -e 's|^mirrorlist=|#mirrorlist=|g' \
     /etc/yum.repos.d/CentOS-Stream-PowerTools.repo \
     /etc/yum.repos.d/CentOS-Stream-RealTime.repo 
 
-RUN dnf config-manager --disable apache-arrow-centos || true
+RUN dnf config-manager --disable apache-arrow-centos,tcmu-runner,tcmu-runner-source,tcmu-runner-noarch || true
 
 RUN yum clean all && yum makecache 
 

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -7,4 +7,4 @@ metadata:
   name: rbd.csi.ceph.com
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1131,10 +1131,12 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		ro = "true"
 	}
 
-	block := "false"
+	volctx := req.GetVolumeContext()
+	var block string
 
-	if _, ok := req.GetVolumeContext()["writeBlock"]; ok {
-		block = "true"
+	if _, ok := volctx["writeBlock"]; ok {
+
+		block = volctx["writeBlock"]
 	}
 
 	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro, "writeBlock": block}}, nil

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1131,16 +1131,10 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	if req.GetReadonly() {
 		ro = "true"
 	}
-	// volctx := req.GetVolumeContext()
-	// var block string
 
-	// if _, ok := volctx["writeBlock"]; ok {
-
-	// 	block = volctx["writeBlock"]
-	// }
-
-	// return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro, "writeBlock": block}}, nil
-	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro}}, nil
+	mode := req.GetVolumeCapability().GetAccessMode().GetMode()
+	am := csi.VolumeCapability_AccessMode_Mode_name[int32(mode)]
+	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro, "Capability": am}}, nil
 }
 
 // ControllerUnpublishVolume does nothing.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1131,7 +1131,13 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		ro = "true"
 	}
 
-	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro}}, nil
+	block := "false"
+
+	if _, ok := req.GetVolumeContext()["writeBlock"]; ok {
+		block = "true"
+	}
+
+	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro, "writeBlock": block}}, nil
 }
 
 // ControllerUnpublishVolume does nothing.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -677,7 +677,8 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 
 	for _, capability := range req.VolumeCapabilities {
-		if capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+		if capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER ||
+			capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
 			return &csi.ValidateVolumeCapabilitiesResponse{Message: ""}, nil
 		}
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -677,7 +677,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 
 	for _, capability := range req.VolumeCapabilities {
-		if capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER ||
+		if capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER &&
 			capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
 			return &csi.ValidateVolumeCapabilitiesResponse{Message: ""}, nil
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1130,16 +1130,16 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	if req.GetReadonly() {
 		ro = "true"
 	}
+	// volctx := req.GetVolumeContext()
+	// var block string
 
-	volctx := req.GetVolumeContext()
-	var block string
+	// if _, ok := volctx["writeBlock"]; ok {
 
-	if _, ok := volctx["writeBlock"]; ok {
+	// 	block = volctx["writeBlock"]
+	// }
 
-		block = volctx["writeBlock"]
-	}
-
-	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro, "writeBlock": block}}, nil
+	// return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro, "writeBlock": block}}, nil
+	return &csi.ControllerPublishVolumeResponse{PublishContext: map[string]string{readonlyAttachmentKey: ro}}, nil
 }
 
 // ControllerUnpublishVolume does nothing.

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -142,7 +142,7 @@ func (r *Driver) Run(conf *util.Config) {
 		// will work those as follow up features
 		r.cd.AddVolumeCapabilityAccessModes(
 			[]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-				csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER})
+				csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY})
 	}
 
 	// Create GRPC servers

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -120,13 +120,13 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	// same with external-attacher's volcap ?
 	// if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
 	if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
-		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+		// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
 		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
 			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
 		}
-	} else {
-		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
-	}
+	// } else {
+	// 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+	// }
 
 	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -459,7 +459,9 @@ func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeS
 		}
 	}
 	if csicommon.MountOptionContains(opt, rOnly) {
+		// readOnly mount with noload option
 		readOnly = true
+		opt = append(opt, "noload")
 	}
 
 	if fsType == "xfs" {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -421,8 +421,13 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		req.Readonly = ro
 	}
+	if _, ok := req.GetPublishContext()[readonlyAttachmentKey]; !ok {
+		if !ro {
+			return nil, status.Errorf(codes.Aborted, "cannot mount readwrite pod for multi readonly capability", volID)
+		}
+	}
 
-	if req.GetPublishContext()[readonlyAttachmentKey] == "true" || req.GetPublishContext()[readonlyAttachmentKey] == "" {
+	if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
 		if !ro {
 			return nil, status.Errorf(codes.Aborted, "cannot mount readwrite pod for multi readonly capability", volID)
 		}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,17 +117,6 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
-	// // same with external-attacher's volcap ?
-	// // if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
-	// if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
-	// 	// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
-	// 	if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
-	// 		return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
-	// 	}
-	// // } else {
-	// // 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
-	// }
-
 	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	// disableInUseChecks := false
@@ -412,14 +401,6 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volID := req.GetVolumeId()
 	stagingPath += "/" + volID
 
-	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
-		// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
-		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
-			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
-		}
-		// } else {
-		// 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
-	}
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
 		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -124,9 +124,9 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
 			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
 		}
-	// } else {
-	// 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
-	// }
+		// } else {
+		// 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+	}
 
 	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -118,8 +118,8 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 
 	// same with external-attacher's volcap ?
-	// if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
-	if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
+	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+		// if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
 		// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
 		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
 			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -131,7 +131,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
 		if !isBlock {
 			util.WarningLog(ctx, "MULTI_NODE_MULTI_WRITER currently only supported with volumes of access type `block`, invalid AccessMode for volume: %v", req.GetVolumeId())
-			return nil, status.Error(codes.InvalidArgument, "rbd: RWX access mode request is only valid for volumes with access type `block`")
+			return nil, status.Error(codes.Internal, "rbd: RWX access mode request is only valid for volumes with access type `block`")
 		}
 
 		disableInUseChecks = true

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -421,11 +421,6 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		req.Readonly = ro
 	}
-	if _, ok := req.GetPublishContext()[readonlyAttachmentKey]; !ok {
-		if !ro {
-			return nil, status.Errorf(codes.Aborted, "cannot mount readwrite pod for multi readonly capability", volID)
-		}
-	}
 
 	if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
 		if !ro {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -131,6 +131,12 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		disableInUseChecks = true
 	}
 
+	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
+			return nil, fmt.Errorf("failed to proceed with RW volume")
+		}
+	}
+
 	volID := req.GetVolumeId()
 
 	cr, err := util.NewUserCredentials(req.GetSecrets())

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -125,7 +125,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
 		if !isBlock {
 			util.WarningLog(ctx, "MULTI_NODE_MULTI_WRITER currently only supported with volumes of access type `block`, invalid AccessMode for volume: %v", req.GetVolumeId())
-			return nil, status.Error(codes.Internal, "rbd: RWX access mode request is only valid for volumes with access type `block`")
+			return nil, status.Error(codes.InvalidArgument, "rbd: RWX access mode request is only valid for volumes with access type `block`")
 		}
 
 		disableInUseChecks = true

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -118,7 +118,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 
 	// sync volcap with va's accessmode
-	if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
+	if req.GetPublishContext()["Capability"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
 		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
 	} else {
 		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,6 +117,13 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
+	// sync volcap with va's accessmode
+	if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
+		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+	} else {
+		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+	}
+
 	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	// disableInUseChecks := false

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -408,7 +408,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volID := req.GetVolumeId()
 	stagingPath += "/" + volID
 
-	// set podinfoonmount = true to get the actual pod info
+	// set podInfoOnMount = true to get the actual pod info
 	podName := req.GetVolumeContext()["csi.storage.k8s.io/pod.name"]
 	podNamespace := req.GetVolumeContext()["csi.storage.k8s.io/pod.namespace"]
 
@@ -422,8 +422,10 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		req.Readonly = ro
 	}
 
-	if !ro && req.GetPublishContext()[readonlyAttachmentKey] == "true" {
-		return nil, status.Errorf(codes.Aborted, "cannot mount readwrite pod for multi readonly capability", volID)
+	if req.GetPublishContext()[readonlyAttachmentKey] == "true" || req.GetPublishContext()[readonlyAttachmentKey] == "" {
+		if !ro {
+			return nil, status.Errorf(codes.Aborted, "cannot mount readwrite pod for multi readonly capability", volID)
+		}
 	}
 
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,16 +117,16 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
-	// same with external-attacher's volcap ?
-	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
-		// if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
-		// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
-		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
-			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
-		}
-		// } else {
-		// 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
-	}
+	// // same with external-attacher's volcap ?
+	// // if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+	// if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
+	// 	// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+	// 	if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
+	// 		return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
+	// 	}
+	// // } else {
+	// // 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+	// }
 
 	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
@@ -412,6 +412,14 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volID := req.GetVolumeId()
 	stagingPath += "/" + volID
 
+	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+		// req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
+			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
+		}
+		// } else {
+		// 	req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+	}
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
 		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -117,10 +117,15 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, err
 	}
 
-	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+	// same with external-attacher's volcap ?
+	// if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+	if req.GetPublishContext()["accessmode"] == csi.VolumeCapability_AccessMode_Mode_name[1] {
+		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
 		if req.GetPublishContext()[readonlyAttachmentKey] == "true" {
 			return nil, status.Error(codes.InvalidArgument, "vol has already been mount as ReadWrite on another node")
 		}
+	} else {
+		req.VolumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
 	}
 
 	disableInUseChecks := req.GetPublishContext()[readonlyAttachmentKey] == "true"

--- a/internal/util/readonly.go
+++ b/internal/util/readonly.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func CheckIfReadonlyMount(po *v1.Pod) (bool, error) {
+	for _, vol := range po.Spec.Volumes {
+		if vol.PersistentVolumeClaim != nil {
+
+			if !vol.PersistentVolumeClaim.ReadOnly {
+				for _, con := range po.Spec.Containers {
+					if con.VolumeMounts == nil {
+						continue
+					}
+					for _, vm := range con.VolumeMounts {
+						if vm.Name == vol.Name && vm.ReadOnly {
+							return true, nil
+						}
+					}
+				}
+				return false, nil
+			}
+			return true, nil
+
+		}
+	}
+	return false, fmt.Errorf("no matching conditions")
+}
+
+func GetPod(name string, namespace string) (*v1.Pod, error) {
+	c := NewK8sClient()
+	pod, err := c.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+
+	if err != nil {
+		klog.V(6).Infof("Can't get pod %s namespace %s: %v", name, namespace, err)
+		return nil, err
+	}
+
+	return pod, nil
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Adding noload option for readonly mount condition to avoid journal replay


Provide any external context for the change, if any.

From log:

Warning  FailedMount             20m   kubelet                  MountVolume.MountDevice failed for volume "pvc-5841825d-31fc-49af-b7f6-dfaefadc7daf" : rpc error: code = Internal desc = 'fsck' found errors on device /dev/rbd1 but could not correct them: fsck from util-linux 2.32.1
/dev/rbd1: Superblock needs_recovery flag is clear, but journal has data.
/dev/rbd1: Run journal anyway

/dev/rbd1: UNEXPECTED INCONSISTENCY; RUN fsck MANUALLY.

## Related issues ##

## Future concerns ##

May need further testing in prd environments

---

